### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,15 +30,15 @@
   },
   "homepage": "https://github.com/aghassemi/tap-xunit",
   "devDependencies": {
-    "tape": "~3.0.3",
-    "concat-stream": "~1.4.7"
+    "tape": "~4.2.2",
+    "concat-stream": "~1.5.1"
   },
   "dependencies": {
-    "through2": "~0.6.3",
-    "xmlbuilder": "~2.4.5",
+    "through2": "~2.0.0",
+    "xmlbuilder": "~4.1.0",
     "duplexer": "~0.1.1",
     "tap-parser": "~1.2.2",
     "xtend": "~4.0.0",
-    "minimist": "~1.1.0"
+    "minimist": "~1.2.0"
   }
 }


### PR DESCRIPTION
currently there is an warning
```
npm WARN deprecated lodash-node@2.4.1: This package is no longer maintained. See its readme for upgrade details.
```
when installing `tap-xunit`. This is because old `xmlbuilder` uses outdated lodash. So I've updated it and other dependencies.