### PR TITLE
strip out ansi characters (fixes #6)

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -3,6 +3,7 @@ var through = require('through2');
 var duplexer = require('duplexer');
 var xmlbuilder = require('xmlbuilder');
 var extend = require('xtend');
+var stripAnsi = require('strip-ansi');
 
 module.exports = converter;
 
@@ -102,7 +103,7 @@ function converter(options) {
       indent: '  ',
       newline: '\n'
     });
-    outStream.push(xmlString + '\n');
+    outStream.push(stripAnsi(xmlString) + '\n');
     outStream.emit('end');
   });
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.3.1",
   "description": "TAP to xUnit XML converter.",
   "main": "lib/converter.js",
-  "bin" : {
-    "tap-xunit" : "./bin/tap-xunit",
-    "txunit" : "./bin/tap-xunit"
+  "bin": {
+    "tap-xunit": "./bin/tap-xunit",
+    "txunit": "./bin/tap-xunit"
   },
   "scripts": {
     "test": "node test/runner.js"
@@ -34,11 +34,12 @@
     "concat-stream": "~1.5.1"
   },
   "dependencies": {
+    "duplexer": "~0.1.1",
+    "minimist": "~1.2.0",
+    "strip-ansi": "^3.0.1",
+    "tap-parser": "~1.2.2",
     "through2": "~2.0.0",
     "xmlbuilder": "~4.1.0",
-    "duplexer": "~0.1.1",
-    "tap-parser": "~1.2.2",
-    "xtend": "~4.0.0",
-    "minimist": "~1.2.0"
+    "xtend": "~4.0.0"
   }
 }

--- a/test/expected/ansi
+++ b/test/expected/ansi
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="test1 › this is ta thing" tests="1" failures="0" errors="0">
+    <testcase name="#1 test1 › this is ta thing"/>
+  </testsuite>
+  <testsuite name="test2 › this is ta thing" tests="1" failures="0" errors="0">
+    <testcase name="#2 test2 › this is ta thing"/>
+  </testsuite>
+</testsuites>

--- a/test/input/ansi
+++ b/test/input/ansi
@@ -1,0 +1,11 @@
+TAP version 13
+# test1 [90m[2m›[22m[39m this is ta thing
+ok 1 - test1 [90m[2m›[22m[39m this is ta thing
+# test2 [90m[2m›[22m[39m this is ta thing
+ok 2 - test2 [90m[2m›[22m[39m this is ta thing
+
+1..2
+# tests 2
+# pass 2
+# fail 0
+


### PR DESCRIPTION
This strips out ansi characters to ensure that output from some test runners (such as `ava`) does not make it down into the output as invalid XML.

See also: https://github.com/sindresorhus/ava/pull/792 