### PR TITLE
Stdout output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+*.swp

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -1,7 +1,6 @@
 var parser = require('tap-parser');
 var through = require('through2');
 var duplexer = require('duplexer');
-var xmlbuilder = require('xmlbuilder');
 var extend = require('xtend');
 var serialize = require('./serialize');
 

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -83,6 +83,10 @@ function converter(options) {
     }
   });
 
+  tapParser.on('extra', function(line) {
+    console.log('EXTRA: ' + line);
+  });
+
   tapParser.on('plan', function(p) {
     // we got to the end, ignore any tests after it
     closeCurTest();

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -76,7 +76,9 @@ function converter(options) {
 
   tapParser.on('complete', function(r) {
     // output any parse errors
-    if(testCase && !testSuites.find(ts => ts.id === testCase.id)) {
+    if(testCase && !testSuites.find(function(ts) {
+        return ts.id === testCase.id;
+    })) {
       testSuites.push(testCase);
     }
     if (r.failures) {

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -3,6 +3,7 @@ var through = require('through2');
 var duplexer = require('duplexer');
 var xmlbuilder = require('xmlbuilder');
 var extend = require('xtend');
+var serialize = require('./serialize');
 
 module.exports = converter;
 
@@ -34,12 +35,7 @@ function converter(options) {
 
   var testSuites = [];
   var testCase;
-  var curTestXml;
   var noMoreTests = false;
-  var curNumTests = 0;
-  var curNumFailed = 0;
-  var curNumSkipped = 0;
-  
   var exitCode = 0;
 
   // create the xunit XML root
@@ -53,35 +49,23 @@ function converter(options) {
     if (noMoreTests) {
       return;
     }
-    // close the current test, if any.
-    closeCurTest();
     // create new test
     newTest(comment);
   });
 
   tapParser.on('assert', function(assert) {
     // no test name was given, so all asserts go in a single test
-    if (!curTestXml) {
+    if (!testCase) {
       newTest('Default');
     }
 
-    var testCaseXml = curTestXml.ele('testcase', {
-      name: '#' + assert.id + ' ' + assert.name
-    });
+    testCase.asserts.push(assert);
+    testSuites.push(testCase);
+  });
 
-    curNumTests++;
-    if (assert.skip) {
-      curNumSkipped++;
-      testCaseXml.ele('skipped');
-    } else {
-      if (!assert.ok) {
-        curNumFailed++;
-        exitCode = 1;
-        var failureXml = testCaseXml.ele('failure');
-        if(assert.diag) {
-          failureXml.txt(formatFailure(assert.diag));
-        }
-      }
+  tapParser.on('extra', function (e) {
+    if(testCase) {
+        testCase.extra.push(e);
     }
   });
 
@@ -90,13 +74,14 @@ function converter(options) {
   });
 
   tapParser.on('plan', function(p) {
-    // we got to the end, ignore any tests after it
-    closeCurTest();
     noMoreTests = true;
   });
 
   tapParser.on('complete', function(r) {
     // output any parse errors
+    if(testCase && testCase.testName && !testSuites.length) {
+      testSuites.push(testCase);
+    }
     if (r.failures) {
       r.failures.forEach(function(fail) {
         if (fail.tapError) {
@@ -105,12 +90,8 @@ function converter(options) {
         }
       });
     }
-    // prettify and output the xUnit xml.
-    var xmlString = rootXml.end({
-      pretty: true,
-      indent: '  ',
-      newline: '\n'
-    });
+    console.log('testSuites', testSuites);
+    var xmlString = serialize(testSuites);
     outStream.push(xmlString + '\n');
     outStream.emit('end');
     result.exitCode = exitCode;
@@ -121,25 +102,11 @@ function converter(options) {
   return result;
 
   function newTest(testName) {
-    testName = formatTestName(testName);
-    curNumTests = 0;
-    curNumFailed = 0;
-    curNumSkipped = 0;
-    curTestXml = rootXml.ele('testsuite', {
-      name: testName
-    });
-  }
-
-  function closeCurTest() {
-    // close the previous test if there is one.
-    if (curTestXml) {
-      curTestXml.att('tests', curNumTests);
-      curTestXml.att('failures', curNumFailed);
-      if (curNumSkipped > 0) {
-        curTestXml.att('skipped', curNumSkipped);
-      }
-      curTestXml.att('errors', 0);
-    }
+    testCase = {
+        extra: [],
+        asserts: [],
+        testName: formatTestName(testName)
+    };
   }
 
   function formatTestName(testName) {
@@ -155,20 +122,5 @@ function converter(options) {
       testName = testName.substr(1);
     }
     return testName.trim();
-  }
-
-  function formatFailure(diag) {
-    var text = '\n          ---\n';
-
-    for(var key in diag) {
-      if(diag.hasOwnProperty(key) && diag[key] !== undefined) {
-        var value = diag[key];
-        text += '            '+key+': ' + (typeof value === 'object' ? JSON.stringify(value) : value) + '\n';
-      }
-    }
-
-    text += '          ...\n      ';
-
-    return text;
   }
 }

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -76,9 +76,9 @@ function converter(options) {
 
   tapParser.on('complete', function(r) {
     // output any parse errors
-    if(testCase && !testSuites.find(function(ts) {
+    if(testCase && !testSuites.filter(function(ts) {
         return ts.id === testCase.id;
-    })) {
+    }).length) {
       testSuites.push(testCase);
     }
     if (r.failures) {

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -32,6 +32,8 @@ function converter(options) {
   var tapParser = parser();
   tapParser.strict = options.strict;
 
+  var testSuites = [];
+  var testCase;
   var curTestXml;
   var noMoreTests = false;
   var curNumTests = 0;

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -38,9 +38,6 @@ function converter(options) {
   var noMoreTests = false;
   var exitCode = 0;
 
-  // create the xunit XML root
-  var rootXml = xmlbuilder.create('testsuites');
-
   tapParser.on('comment', function(comment) {
     // comment specifies boundaries between testsuites, unless feature disabled.
     if (options.dontUseCommentsAsTestNames) {
@@ -50,17 +47,16 @@ function converter(options) {
       return;
     }
     // create new test
-    newTest(comment);
+    testCase = newTest(comment);
   });
 
   tapParser.on('assert', function(assert) {
     // no test name was given, so all asserts go in a single test
     if (!testCase) {
-      newTest('Default');
+      testCase = newTest('Default');
     }
 
     testCase.asserts.push(assert);
-    testSuites.push(testCase);
   });
 
   tapParser.on('extra', function (e) {
@@ -70,7 +66,6 @@ function converter(options) {
   });
 
   tapParser.on('extra', function(line) {
-    console.log('EXTRA: ' + line);
   });
 
   tapParser.on('plan', function(p) {
@@ -79,7 +74,7 @@ function converter(options) {
 
   tapParser.on('complete', function(r) {
     // output any parse errors
-    if(testCase && testCase.testName && !testSuites.length) {
+    if(testCase && !testSuites.find(ts => ts.id === testCase.id)) {
       testSuites.push(testCase);
     }
     if (r.failures) {
@@ -90,7 +85,6 @@ function converter(options) {
         }
       });
     }
-    console.log('testSuites', testSuites);
     var xmlString = serialize(testSuites);
     outStream.push(xmlString + '\n');
     outStream.emit('end');
@@ -102,11 +96,13 @@ function converter(options) {
   return result;
 
   function newTest(testName) {
-    testCase = {
+    testSuites.push({
+        id: testSuites.length,
         extra: [],
         asserts: [],
         testName: formatTestName(testName)
-    };
+    });
+    return testSuites[testSuites.length -1];
   }
 
   function formatTestName(testName) {

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -56,6 +56,9 @@ function converter(options) {
       testCase = newTest('Default');
     }
 
+    if(!assert.ok) {
+        exitCode = 1;
+    }
     testCase.asserts.push(assert);
   });
 

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -3,34 +3,35 @@ const xmlbuilder = require('xmlbuilder');
 module.exports = function serialize (testCases) {
   var rootXml = xmlbuilder.create('testsuites');
   testCases.forEach(suite => {
-      const suiteElement = rootXml.ele('testsuite');
-      suiteElement.att('tests', suite.asserts.length);
-      const skipped = suite.asserts.filter(a => a.skip).length;
-      if (skipped) {
-          suiteElement.att('skipped', skipped);
-      }
-      suiteElement.att('failures', suite.asserts.filter(a => !a.ok).length);
-      suiteElement.att('errors', '0');
-      suiteElement.att('name', suite.testName || '');
-      suite.asserts.forEach((a, i) => {
-        const testCaseElement = suiteElement.ele('testcase', {
-            name: '#' + a.id + ' ' + a.name
-        });
-        if(a.skip) {
-            testCaseElement.ele('skipped');
-        }
-        if(!a.ok) {
-            const failureElement = testCaseElement.ele('failure');
-            if(a.diag) {
-              failureElement.txt(formatFailure(a.diag));
-            }
-        }
-        if(i === suite.asserts.length -1) {
-          suite.extra.forEach(e => {
-            testCaseElement.ele('sysout', e);
-          });
-        }
+    const suiteElement = rootXml.ele('testsuite');
+    suiteElement.att('tests', suite.asserts.length);
+    const skipped = suite.asserts.filter(a => a.skip).length;
+    if (skipped) {
+      suiteElement.att('skipped', skipped);
+    }
+    suiteElement.att('failures', suite.asserts
+      .filter(a => !a.ok && !a.skip).length);
+    suiteElement.att('errors', '0');
+    suiteElement.att('name', suite.testName || '');
+    suite.asserts.forEach((a, i) => {
+      const testCaseElement = suiteElement.ele('testcase', {
+          name: '#' + a.id + ' ' + a.name
       });
+      if(a.skip) {
+          testCaseElement.ele('skipped');
+      }
+      if(!a.ok && !a.skip) {
+          const failureElement = testCaseElement.ele('failure');
+          if(a.diag) {
+            failureElement.txt(formatFailure(a.diag));
+          }
+      }
+      if(i === suite.asserts.length -1) {
+        suite.extra.forEach(e => {
+          testCaseElement.ele('sysout', e);
+        });
+      }
+    });
   });
   return rootXml.end({
     pretty: true,

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -28,7 +28,7 @@ module.exports = function serialize (testCases) {
       }
       if(i === suite.asserts.length -1) {
         suite.extra.forEach(e => {
-          testCaseElement.ele('sysout', e);
+          testCaseElement.ele('system-out', e);
         });
       }
     });

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -1,33 +1,39 @@
-const xmlbuilder = require('xmlbuilder');
+var xmlbuilder = require('xmlbuilder');
 
 module.exports = function serialize (testCases) {
   var rootXml = xmlbuilder.create('testsuites');
-  testCases.forEach(suite => {
-    const suiteElement = rootXml.ele('testsuite');
+  testCases.forEach(function(suite) {
+    var suiteElement = rootXml.ele('testsuite');
+    var skipped;
+    var failureElement;
     suiteElement.att('tests', suite.asserts.length);
-    const skipped = suite.asserts.filter(a => a.skip).length;
+    skipped = suite.asserts.filter(function (a) {
+        return a.skip;
+    }).length;
     if (skipped) {
       suiteElement.att('skipped', skipped);
     }
     suiteElement.att('failures', suite.asserts
-      .filter(a => !a.ok && !a.skip).length);
+      .filter(function (a) {
+          return !a.ok && !a.skip;
+      }).length);
     suiteElement.att('errors', '0');
     suiteElement.att('name', suite.testName || '');
-    suite.asserts.forEach((a, i) => {
-      const testCaseElement = suiteElement.ele('testcase', {
+    suite.asserts.forEach(function (a, i) {
+      var testCaseElement = suiteElement.ele('testcase', {
           name: '#' + a.id + ' ' + a.name
       });
       if(a.skip) {
           testCaseElement.ele('skipped');
       }
       if(!a.ok && !a.skip) {
-          const failureElement = testCaseElement.ele('failure');
+          failureElement = testCaseElement.ele('failure');
           if(a.diag) {
             failureElement.txt(formatFailure(a.diag));
           }
       }
       if(i === suite.asserts.length -1) {
-        suite.extra.forEach(e => {
+        suite.extra.forEach(function (e) {
           testCaseElement.ele('system-out', e);
         });
       }

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -12,7 +12,7 @@ module.exports = function serialize (testCases) {
       suiteElement.att('failures', suite.asserts.filter(a => !a.ok).length);
       suiteElement.att('errors', '0');
       suiteElement.att('name', suite.testName || '');
-      suite.asserts.forEach(a => {
+      suite.asserts.forEach((a, i) => {
         const testCaseElement = suiteElement.ele('testcase', {
             name: '#' + a.id + ' ' + a.name
         });
@@ -25,9 +25,11 @@ module.exports = function serialize (testCases) {
               failureElement.txt(formatFailure(a.diag));
             }
         }
-      });
-      suite.extra.forEach(e => {
-        suiteElement.ele('sysout', e);
+        if(i === suite.asserts.length -1) {
+          suite.extra.forEach(e => {
+            testCaseElement.ele('sysout', e);
+          });
+        }
       });
   });
   return rootXml.end({

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -1,0 +1,53 @@
+const xmlbuilder = require('xmlbuilder');
+
+module.exports = function serialize (testCases) {
+  var rootXml = xmlbuilder.create('testsuites');
+  testCases.forEach(suite => {
+      const suiteElement = rootXml.ele('testsuite');
+      suiteElement.att('tests', suite.asserts.length);
+      const skipped = suite.asserts.filter(a => a.skip).length;
+      if (skipped) {
+          suiteElement.att('skipped', skipped);
+      }
+      suiteElement.att('failures', suite.asserts.filter(a => !a.ok).length);
+      suiteElement.att('errors', '0');
+      suiteElement.att('name', suite.testName || '');
+      suite.asserts.forEach(a => {
+        const testCaseElement = suiteElement.ele('testcase', {
+            name: '#' + a.id + ' ' + a.name
+        });
+        if(a.skip) {
+            testCaseElement.ele('skipped');
+        }
+        if(!a.ok) {
+            const failureElement = testCaseElement.ele('failure');
+            if(a.diag) {
+              failureElement.txt(formatFailure(a.diag));
+            }
+        }
+      });
+      suite.extra.forEach(e => {
+        suiteElement.ele('sysout', e);
+      });
+  });
+  return rootXml.end({
+    pretty: true,
+    indent: '  ',
+    newline: '\n'
+  });
+}
+
+function formatFailure(diag) {
+  var text = '\n          ---\n';
+
+  for(var key in diag) {
+    if(diag.hasOwnProperty(key) && diag[key] !== undefined) {
+      var value = diag[key];
+      text += '            '+key+': ' + (typeof value === 'object' ? JSON.stringify(value) : value) + '\n';
+    }
+  }
+
+  text += '          ...\n      ';
+
+  return text;
+}

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "1.4.0",
   "description": "TAP to xUnit XML converter.",
   "main": "lib/converter.js",
-  "bin" : {
-    "tap-xunit" : "./bin/tap-xunit",
-    "txunit" : "./bin/tap-xunit"
+  "bin": {
+    "tap-xunit": "./bin/tap-xunit",
+    "txunit": "./bin/tap-xunit"
   },
   "scripts": {
-    "test": "node test/runner.js"
+    "test": "node test/runner.js && tape unit-tests/**/*.js"
   },
   "repository": {
     "type": "git",
@@ -30,8 +30,9 @@
   },
   "homepage": "https://github.com/aghassemi/tap-xunit",
   "devDependencies": {
+    "concat-stream": "~1.5.1",
     "tape": "~4.2.2",
-    "concat-stream": "~1.5.1"
+    "xml2js": "^0.4.17"
   },
   "dependencies": {
     "through2": "~2.0.0",

--- a/test/expected/fail/eslint
+++ b/test/expected/fail/eslint
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <testsuites>
-  <testsuite name="Default">
+  <testsuite name="Default" tests="12" failures="1" errors="0">
     <testcase name="#1 /Users/nkbt/github/npm-http-server/modules/__tests__/getProperty-test.js"/>
     <testcase name="#2 /Users/nkbt/github/npm-http-server/modules/__tests__/parsePackageURL-test.js"/>
     <testcase name="#3 /Users/nkbt/github/npm-http-server/modules/createPackageURL.js"/>

--- a/test/expected/pass/with-log
+++ b/test/expected/pass/with-log
@@ -2,7 +2,7 @@
 <testsuites>
   <testsuite name="console logs" tests="1" failures="0" errors="0">
     <testcase name="#1 should be equal">
-        <sysout>hi there&#10;</sysout>
+        <system-out>hi there&#10;</system-out>
     </testcase>
   </testsuite>
 </testsuites>

--- a/test/expected/pass/with-log
+++ b/test/expected/pass/with-log
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <testsuites>
-  <testsuite name="single pass" tests="1" failures="0" errors="0">
+  <testsuite name="console logs" tests="1" failures="0" errors="0">
     <testcase name="#1 should be equal">
-        <sysout>hi there</sysout>
+        <sysout>hi there&#10;</sysout>
     </testcase>
   </testsuite>
 </testsuites>

--- a/test/expected/pass/with-log
+++ b/test/expected/pass/with-log
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="single pass" tests="1" failures="0" errors="0">
+    <testcase name="#1 should be equal">
+        <sysout>hi there</sysout>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/test/input/pass/with-log
+++ b/test/input/pass/with-log
@@ -1,0 +1,9 @@
+TAP version 13
+# console logs
+hi there
+
+1..0
+# tests 0
+# pass  0
+
+# ok

--- a/test/input/pass/with-log
+++ b/test/input/pass/with-log
@@ -1,9 +1,10 @@
 TAP version 13
 # console logs
 hi there
+ok 1 should be equal
 
 1..0
-# tests 0
-# pass  0
+# tests 1
+# pass  1
 
 # ok

--- a/test/runner.js
+++ b/test/runner.js
@@ -3,6 +3,7 @@ var path = require('path');
 var test = require('tape');
 var concat = require('concat-stream');
 var converter = require('../lib/converter.js');
+var xml2js = require('xml2js');
 
 var FILE_READ_OPTS = {
   encoding: 'utf-8'
@@ -36,9 +37,16 @@ function runGoodInputTests(subdir, exitCode) {
 
       function verifyResults(output) {
         output = output.toString();
-        assert.deepEqual(output.trim(), expected.trim(), 'input/output match');
-        assert.end();
-        assert.equals(exitCode, tapToxUnitConverter.exitCode, 'exitCode match');
+        xml2js.parseString(output, function (err, parsedOutput) {
+            console.log('EXPECTED');
+            console.dir(expected, {depth: null});
+            console.log('ACTUAL');
+            console.dir(parsedOutput, {depth: null});
+            assert.deepEqual(parsedOutput, expected, 'input/output match');
+            assert.end();
+            assert.equals(exitCode,
+                tapToxUnitConverter.exitCode, 'exitCode match');
+        });
       }
     });
   }
@@ -50,7 +58,9 @@ function runGoodInputTests(subdir, exitCode) {
     var inputStream = fs.createReadStream(inputFilePath, FILE_READ_OPTS);
     fs.readFile(expectedFilePath, FILE_READ_OPTS, function(err, output) {
       if (err) throw err;
-      cb(inputStream, output);
+      xml2js.parseString(output, function (err, parsed) {
+          cb(inputStream, parsed);
+      });
     });
   }
 }

--- a/unit-tests/serialization-tests.js
+++ b/unit-tests/serialization-tests.js
@@ -1,7 +1,7 @@
-const test = require('tape');
-const xmlbuilder = require('xmlbuilder');
-const xml2js = require('xml2js');
-const serialize = require('../lib/serialize');
+var test = require('tape');
+var xmlbuilder = require('xmlbuilder');
+var xml2js = require('xml2js');
+var serialize = require('../lib/serialize');
 
 [
     {
@@ -113,7 +113,7 @@ const serialize = require('../lib/serialize');
             }
         }
     }
-].forEach(testCase => {
+].forEach(function(testCase) {
     test('serializes: ' + testCase.name, assert => {
         var testSuites = testCase.input;
         var xml = xml2js.parseString(serialize(testSuites), (err, parsed) => {

--- a/unit-tests/serialization-tests.js
+++ b/unit-tests/serialization-tests.js
@@ -6,11 +6,11 @@ const serialize = require('../lib/serialize');
 [
     {
         name: 'Single assert',
-        input: {
+        input: [{
             extra: [],
             asserts: [ { ok: true, id: 3, name: 'should be equal' } ],
             testName: 'hello test'
-        },
+        }],
         expected: {
             testsuites: {
                 testsuite: [{
@@ -24,10 +24,10 @@ const serialize = require('../lib/serialize');
     },
     {
         name: 'skipped assert',
-        input: {
+        input: [{
             extra: [],
             asserts: [ { skip: true, id: 3, ok: 'true', name: 'should be equal' } ]
-        },
+        }],
         expected: {
             testsuites: {
                 testsuite: [{
@@ -44,10 +44,10 @@ const serialize = require('../lib/serialize');
     },
     {
         name: 'failed assert',
-        input: {
+        input: [{
             extra: [],
             asserts: [ { skip: false, id: 3, ok: false, name: 'should be equal' } ]
-        },
+        }],
         expected: {
             testsuites: {
                 testsuite: [{
@@ -64,7 +64,7 @@ const serialize = require('../lib/serialize');
     },
     {
         name: 'failed assert with diag',
-        input: {
+        input: [{
             extra: [],
             asserts: [ {
                 skip: false, id: 3, ok: false, name: 'should be equal',
@@ -73,7 +73,7 @@ const serialize = require('../lib/serialize');
                     at: 'Test'
                 }
             } ]
-        },
+        }],
         expected: {
             testsuites: {
                 testsuite: [{
@@ -91,13 +91,13 @@ const serialize = require('../lib/serialize');
     },
     {
         name: 'stdout logs',
-        input: {
+        input: [{
           extra: [ 'see me\n', 'me too\n' ],
           asserts: [
               { ok: true, id: 1, name: 'should be equal' },
               { ok: true, id: 2, name: 'should be equal' }
           ]
-        },
+        }],
         expected: {
             testsuites: {
                 testsuite: [{
@@ -113,8 +113,8 @@ const serialize = require('../lib/serialize');
     }
 ].forEach(testCase => {
     test('serializes: ' + testCase.name, assert => {
-        var asserts = [testCase.input];
-        var xml = xml2js.parseString(serialize(asserts), (err, parsed) => {
+        var testSuites = testCase.input;
+        var xml = xml2js.parseString(serialize(testSuites), (err, parsed) => {
             var expected = testCase.expected;
             console.log('EXPECTED');
             console.dir(expected, {depth: null});

--- a/unit-tests/serialization-tests.js
+++ b/unit-tests/serialization-tests.js
@@ -1,0 +1,98 @@
+const test = require('tape');
+const xmlbuilder = require('xmlbuilder');
+const xml2js = require('xml2js');
+
+[
+    {
+        name: 'Single assert',
+        input: {
+            extra: [],
+            asserts: [ { ok: true, id: 3, name: 'should be equal' } ]
+        },
+        expected: {
+            '$': { tests: '1', failures: '0', skipped: '0' },
+            testcase: [
+                { '$': { name: '#3 should be equal' } }
+            ]
+        }
+    },
+    {
+        name: 'skipped assert',
+        input: {
+            extra: [],
+            asserts: [ { skip: true, id: 3, ok: 'true', name: 'should be equal' } ]
+        },
+        expected: {
+            '$': { tests: '1', failures: '0', skipped: '1' },
+            testcase: [
+                {
+                    '$': { name: '#3 should be equal' },
+                    skipped: ['']
+                }
+            ]
+        }
+    },
+    {
+        name: 'stdout logs',
+        input: {
+          extra: [ 'see me\n', 'me too\n' ],
+          asserts: [
+              { ok: true, id: 1, name: 'should be equal' },
+              { ok: true, id: 2, name: 'should be equal' }
+          ]
+        },
+        expected: {
+            '$': { tests: '2', failures: '0', skipped: '0' },
+            testcase: [
+                { '$': { name: '#1 should be equal' } },
+                { '$': { name: '#2 should be equal' } },
+            ],
+            sysout: [ 'see me\n', 'me too\n' ]
+        }
+    }
+].forEach(testCase => {
+    test('serializes: ' + testCase.name, assert => {
+        var asserts = [testCase.input];
+        var xml = xml2js.parseString(serialize(asserts), (err, parsed) => {
+            console.dir(parsed, {depth: null});
+            var expected = {
+                testsuites: {
+                    testsuite: [testCase.expected]
+                }
+            };
+            console.log('EXPECTED');
+            console.dir(expected, {depth: null});
+            console.log('ACTUAL');
+            console.dir(parsed, {depth: null});
+            assert.deepEqual(parsed, expected);
+            assert.end();
+        });
+    });
+});
+
+function serialize (testCases) {
+  var rootXml = xmlbuilder.create('testsuites');
+  testCases.forEach(suite => {
+      const suiteElement = rootXml.ele('testsuite');
+      suiteElement.att('tests', suite.asserts.length);
+      suiteElement.att('skipped', suite.asserts.filter(a => a.skip).length);
+      suiteElement.att('failures', suite.asserts.filter(a => !a.ok).length);
+      suite.asserts.forEach(a => {
+        const testCaseElement = suiteElement.ele('testcase', {
+            name: '#' + a.id + ' ' + a.name
+        });
+        if(a.skip) {
+            testCaseElement.ele('skipped');
+        }
+      });
+      suite.extra.forEach(e => {
+        suiteElement.ele('sysout', e);
+      });
+  });
+  return rootXml.end({
+    pretty: true,
+    indent: '  ',
+    newline: '\n'
+  });
+}
+

--- a/unit-tests/serialization-tests.js
+++ b/unit-tests/serialization-tests.js
@@ -106,7 +106,7 @@ const serialize = require('../lib/serialize');
                         { '$': { name: '#1 should be equal' } },
                         {
                             '$': { name: '#2 should be equal' },
-                            sysout: [ 'see me\n', 'me too\n' ]
+                            'system-out': [ 'see me\n', 'me too\n' ]
                         },
                     ],
                 }]

--- a/unit-tests/serialization-tests.js
+++ b/unit-tests/serialization-tests.js
@@ -33,6 +33,22 @@ const xml2js = require('xml2js');
         }
     },
     {
+        name: 'failed assert',
+        input: {
+            extra: [],
+            asserts: [ { skip: false, id: 3, ok: false, name: 'should be equal' } ]
+        },
+        expected: {
+            '$': { tests: '1', failures: '1', skipped: '0' },
+            testcase: [
+                {
+                    '$': { name: '#3 should be equal' },
+                    failure: ['']
+                }
+            ]
+        }
+    },
+    {
         name: 'stdout logs',
         input: {
           extra: [ 'see me\n', 'me too\n' ],
@@ -54,7 +70,6 @@ const xml2js = require('xml2js');
     test('serializes: ' + testCase.name, assert => {
         var asserts = [testCase.input];
         var xml = xml2js.parseString(serialize(asserts), (err, parsed) => {
-            console.dir(parsed, {depth: null});
             var expected = {
                 testsuites: {
                     testsuite: [testCase.expected]
@@ -83,6 +98,9 @@ function serialize (testCases) {
         });
         if(a.skip) {
             testCaseElement.ele('skipped');
+        }
+        if(!a.ok) {
+            testCaseElement.ele('failure');
         }
       });
       suite.extra.forEach(e => {

--- a/unit-tests/serialization-tests.js
+++ b/unit-tests/serialization-tests.js
@@ -114,9 +114,9 @@ var serialize = require('../lib/serialize');
         }
     }
 ].forEach(function(testCase) {
-    test('serializes: ' + testCase.name, assert => {
+    test('serializes: ' + testCase.name, function (assert) {
         var testSuites = testCase.input;
-        var xml = xml2js.parseString(serialize(testSuites), (err, parsed) => {
+        var xml = xml2js.parseString(serialize(testSuites), function(err, parsed) {
             var expected = testCase.expected;
             console.log('EXPECTED');
             console.dir(expected, {depth: null});

--- a/unit-tests/serialization-tests.js
+++ b/unit-tests/serialization-tests.js
@@ -104,9 +104,11 @@ const serialize = require('../lib/serialize');
                     '$': { tests: '2', failures: '0', name: '', errors: '0' },
                     testcase: [
                         { '$': { name: '#1 should be equal' } },
-                        { '$': { name: '#2 should be equal' } },
+                        {
+                            '$': { name: '#2 should be equal' },
+                            sysout: [ 'see me\n', 'me too\n' ]
+                        },
                     ],
-                    sysout: [ 'see me\n', 'me too\n' ]
                 }]
             }
         }

--- a/unit-tests/serialization-tests.js
+++ b/unit-tests/serialization-tests.js
@@ -1,19 +1,25 @@
 const test = require('tape');
 const xmlbuilder = require('xmlbuilder');
 const xml2js = require('xml2js');
+const serialize = require('../lib/serialize');
 
 [
     {
         name: 'Single assert',
         input: {
             extra: [],
-            asserts: [ { ok: true, id: 3, name: 'should be equal' } ]
+            asserts: [ { ok: true, id: 3, name: 'should be equal' } ],
+            testName: 'hello test'
         },
         expected: {
-            '$': { tests: '1', failures: '0', skipped: '0' },
-            testcase: [
-                { '$': { name: '#3 should be equal' } }
-            ]
+            testsuites: {
+                testsuite: [{
+                    '$': { name: 'hello test', tests: '1', failures: '0', errors: '0' },
+                    testcase: [
+                        { '$': { name: '#3 should be equal' } }
+                    ]
+                }]
+            }
         }
     },
     {
@@ -23,13 +29,17 @@ const xml2js = require('xml2js');
             asserts: [ { skip: true, id: 3, ok: 'true', name: 'should be equal' } ]
         },
         expected: {
-            '$': { tests: '1', failures: '0', skipped: '1' },
-            testcase: [
-                {
-                    '$': { name: '#3 should be equal' },
-                    skipped: ['']
-                }
-            ]
+            testsuites: {
+                testsuite: [{
+                    '$': { tests: '1', failures: '0', skipped: '1', name: '', errors: '0' },
+                    testcase: [
+                        {
+                            '$': { name: '#3 should be equal' },
+                            skipped: ['']
+                        }
+                    ]
+                }]
+            }
         }
     },
     {
@@ -39,13 +49,17 @@ const xml2js = require('xml2js');
             asserts: [ { skip: false, id: 3, ok: false, name: 'should be equal' } ]
         },
         expected: {
-            '$': { tests: '1', failures: '1', skipped: '0' },
-            testcase: [
-                {
-                    '$': { name: '#3 should be equal' },
-                    failure: ['']
-                }
-            ]
+            testsuites: {
+                testsuite: [{
+                    '$': { tests: '1', failures: '1', name: '', errors: '0' },
+                    testcase: [
+                        {
+                            '$': { name: '#3 should be equal' },
+                            failure: ['']
+                        }
+                    ]
+                }]
+            }
         }
     },
     {
@@ -61,13 +75,18 @@ const xml2js = require('xml2js');
             } ]
         },
         expected: {
-            '$': { tests: '1', failures: '1', skipped: '0' },
-            testcase: [
-                {
-                    '$': { name: '#3 should be equal' },
-                    failure: ['\n          ---\n            operator: fail\n            at: Test\n          ...\n      ']
-                }
-            ]
+            testsuites: {
+                testsuite: [{
+                    '$': { tests: '1', failures: '1', name: '', errors: '0' },
+                    testcase: [
+                        {
+                            '$': { name: '#3 should be equal' },
+                            failure: [
+                                '\n          ---\n            operator: fail\n            at: Test\n          ...\n      ']
+                        }
+                    ]
+                }]
+            }
         }
     },
     {
@@ -80,23 +99,23 @@ const xml2js = require('xml2js');
           ]
         },
         expected: {
-            '$': { tests: '2', failures: '0', skipped: '0' },
-            testcase: [
-                { '$': { name: '#1 should be equal' } },
-                { '$': { name: '#2 should be equal' } },
-            ],
-            sysout: [ 'see me\n', 'me too\n' ]
+            testsuites: {
+                testsuite: [{
+                    '$': { tests: '2', failures: '0', name: '', errors: '0' },
+                    testcase: [
+                        { '$': { name: '#1 should be equal' } },
+                        { '$': { name: '#2 should be equal' } },
+                    ],
+                    sysout: [ 'see me\n', 'me too\n' ]
+                }]
+            }
         }
     }
 ].forEach(testCase => {
     test('serializes: ' + testCase.name, assert => {
         var asserts = [testCase.input];
         var xml = xml2js.parseString(serialize(asserts), (err, parsed) => {
-            var expected = {
-                testsuites: {
-                    testsuite: [testCase.expected]
-                }
-            };
+            var expected = testCase.expected;
             console.log('EXPECTED');
             console.dir(expected, {depth: null});
             console.log('ACTUAL');
@@ -106,50 +125,3 @@ const xml2js = require('xml2js');
         });
     });
 });
-
-function serialize (testCases) {
-  var rootXml = xmlbuilder.create('testsuites');
-  testCases.forEach(suite => {
-      const suiteElement = rootXml.ele('testsuite');
-      suiteElement.att('tests', suite.asserts.length);
-      suiteElement.att('skipped', suite.asserts.filter(a => a.skip).length);
-      suiteElement.att('failures', suite.asserts.filter(a => !a.ok).length);
-      suite.asserts.forEach(a => {
-        const testCaseElement = suiteElement.ele('testcase', {
-            name: '#' + a.id + ' ' + a.name
-        });
-        if(a.skip) {
-            testCaseElement.ele('skipped');
-        }
-        if(!a.ok) {
-            const failureElement = testCaseElement.ele('failure');
-            if(a.diag) {
-              failureElement.txt(formatFailure(a.diag));
-            }
-        }
-      });
-      suite.extra.forEach(e => {
-        suiteElement.ele('sysout', e);
-      });
-  });
-  return rootXml.end({
-    pretty: true,
-    indent: '  ',
-    newline: '\n'
-  });
-}
-
-function formatFailure(diag) {
-  var text = '\n          ---\n';
-
-  for(var key in diag) {
-    if(diag.hasOwnProperty(key) && diag[key] !== undefined) {
-      var value = diag[key];
-      text += '            '+key+': ' + (typeof value === 'object' ? JSON.stringify(value) : value) + '\n';
-    }
-  }
-
-  text += '          ...\n      ';
-
-  return text;
-}


### PR DESCRIPTION
This will send "extra" lines from tap output to the `system-out` element of the final assert in a suite. This allows for anything logged to stdout during a test run to be visible in a jenkins log.

In order to test this more easily, I've separated out collecting the output from tap and creating the xunit xml file.

I've also introduced a devdependency on xml2js. This makes it slightly clearer to see what's failed than doing a string comparison on the output xml strings.