### PR TITLE
Minor version upgrade of xmlbuilder to pickup security fixes in lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "through2": "~2.0.0",
-    "xmlbuilder": "~4.1.0",
+    "xmlbuilder": "~4.2.0",
     "duplexer": "~0.1.1",
     "tap-parser": "~1.2.2",
     "xtend": "~4.0.0",


### PR DESCRIPTION
By upgrading to xmlbuilder 4.2.0, lodash 4.x will be used and that means security fixes, like the fix for https://snyk.io/vuln/npm:lodash:20180130 , can be picked up.