### PR TITLE
Sanitise suite name and test name

### DIFF
--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -19,10 +19,10 @@ module.exports = function serialize (testCases) {
           return !a.ok && !a.skip;
       }).length);
     suiteElement.att('errors', '0');
-    suiteElement.att('name', suite.testName || '');
+    suiteElement.att('name', sanitizeString(suite.testName || ''));
     suite.asserts.forEach(function (a, i) {
       var testCaseElement = suiteElement.ele('testcase', {
-          name: '#' + a.id + ' ' + a.name
+          name: '#' + a.id + ' ' + sanitizeString(a.name)
       });
       if(a.skip) {
           testCaseElement.ele('skipped');

--- a/test/expected/pass/non-xml-text
+++ b/test/expected/pass/non-xml-text
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="non-xml-text" tests="1" failures="0" errors="0">
+    <testcase name="#1 contains vertical tab here &quot;&#x240B;&quot; and here &quot;&quot;"/>
+  </testsuite>
+</testsuites>

--- a/test/input/pass/non-xml-text
+++ b/test/input/pass/non-xml-text
@@ -1,0 +1,9 @@
+TAP version 13
+# non-xml-text
+ok 1 contains vertical tab here "␋" and here ""
+
+1..1
+# tests 1
+# pass  1
+
+# ok

--- a/unit-tests/xml-sanitization-tests.js
+++ b/unit-tests/xml-sanitization-tests.js
@@ -3,7 +3,10 @@ var sanitizeString = require('../lib/sanitize-string');
 
 [
     '\u0000',
-    '\u0001'
+    '\u0001',
+    '\u000B',
+    '\uD800',
+    '\uFDD0',
 ].forEach(function(invalidCharacter){
     test(
         'it strips the invalid character:' + invalidCharacter.charCodeAt(0),
@@ -16,6 +19,7 @@ var sanitizeString = require('../lib/sanitize-string');
 
 [
     '\u000A',
+    '\u000D',
 ].forEach(function(validCharacter){
     test(
         'it doesn\'t strip the valid character:' + validCharacter.charCodeAt(0),


### PR DESCRIPTION
* TAP tests may contain various non-printable characters in tests names.
  It has been ruining CI tests because there was a test which used VT
  character as part of its name.

* It also adds tests for several other non-printables and surrogates
  that should be removed from output.