### PR TITLE
Consolidate system out under a single element

### DIFF
--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -36,10 +36,12 @@ module.exports = function serialize (testCases) {
       }
       if(i === suite.asserts.length -1) {
         extraContent = [];
-        suite.extra.forEach(function (extraContent) {
-          extraContent.push(sanitizeString(extraContent))
+        suite.extra.forEach(function (extraContentLine) {
+          extraContent.push(sanitizeString(extraContentLine))
         });
-        testCaseElement.ele('system-out', extraContent.join('\n'));
+        if (extraContent.length > 0) {
+          testCaseElement.ele('system-out', extraContent.join(''));
+        }
       }
     });
   });

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -7,6 +7,7 @@ module.exports = function serialize (testCases) {
     var suiteElement = rootXml.ele('testsuite');
     var skipped;
     var failureElement;
+    var extraContent;
     suiteElement.att('tests', suite.asserts.length);
     skipped = suite.asserts.filter(function (a) {
         return a.skip;
@@ -34,9 +35,11 @@ module.exports = function serialize (testCases) {
           }
       }
       if(i === suite.asserts.length -1) {
+        extraContent = [];
         suite.extra.forEach(function (extraContent) {
-          testCaseElement.ele('system-out', sanitizeString(extraContent));
+          extraContent.push(sanitizeString(extraContent))
         });
+        testCaseElement.ele('system-out', extraContent.join('\n'));
       }
     });
   });

--- a/unit-tests/serialization-tests.js
+++ b/unit-tests/serialization-tests.js
@@ -106,7 +106,7 @@ var serialize = require('../lib/serialize');
                         { '$': { name: '#1 should be equal' } },
                         {
                             '$': { name: '#2 should be equal' },
-                            'system-out': [ 'see me\n', 'me too\n' ]
+                            'system-out': [ 'see me\nme too\n' ]
                         },
                     ],
                 }]


### PR DESCRIPTION
Jenkins only displays the first system-out tag. We'd like to see _all_ the system output in Jenkins.