### PR TITLE
TAP diagnostic should go into <system-out/>

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,7 @@ less results.tap | tap-xunit --package="MyCompany.MyTool" > results.xml
 
 ```
 
-By default TAP comments are used as test-suite names and considered to mark test boundaries.
-Without the feature all assertions go inside a single ```<testsuite name="Default">``` with name ```Default```
-Alternatively with CLI flag ```--oneAssertionPerTestcase``` comments are concatenated and included as ```<system-output/>```.
-Or with flag ```--dontUseCommentsAsTestNames``` the test-suite names feature is turned off, and comments are ignored.
+By default TAP comments are used as test-suite names and considered to mark test boundaries. Without the feature all assertions go inside a single ```<testsuite name="Default">``` with name ```Default``` Alternatively with CLI flag ```--oneAssertionPerTestcase``` comments are concatenated and included as ```<system-output/>```. Or with flag ```--dontUseCommentsAsTestNames``` the test-suite names feature is turned off, and comments are ignored. Because not all publishers pick up on ```<system-output/>``` alternatively ```--outputAsFailure``` moves the comments to the ```<failure/>``` element but only if no diagnostic data objects are given.
 
 ## Library
 ```
@@ -67,6 +64,15 @@ This feature exists because many xUnit reporters assume '.' in test-suite name i
 If specified, all test-suites will be prefixed with the given package name.
 NOTE: ```replaceWithUnicodeDot``` option does not apply to package and . can be used to specify package hierarchy.
 
+#### oneAssertionPerTestcase
+*default*: false
+
+Overrides dontUseCommentsAsTestNames, always group comments with assertion before and output in ```<system-output/>```
+
+#### outputAsFailure
+*default*: false
+
+Change behaviour for oneAssertionPerTestcase to move diagnostic comments from system-output to failure. Included only if no other diagnostics are given, and only for failure results.
 
 # License
 MIT

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ less results.tap | tap-xunit --package="MyCompany.MyTool" > results.xml
 
 ```
 
-By default TAP comments are used as test-suite names and considered to mark test boundaries. CLI flag ```--dontUseCommentsAsTestNames``` can be used to turn that feature off, in which case comments are ignored and
-all assertions go inside a single ```<testsuite name="Default">``` with name ```Default```
+By default TAP comments are used as test-suite names and considered to mark test boundaries.
+Without the feature all assertions go inside a single ```<testsuite name="Default">``` with name ```Default```
+Alternatively with CLI flag ```--oneAssertionPerTestcase``` comments are concatenated and included as ```<system-output/>```.
+Or with flag ```--dontUseCommentsAsTestNames``` the test-suite names feature is turned off, and comments are ignored.
 
 ## Library
 ```

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -26,7 +26,9 @@ var defaults = {
 
   // Instead of CommentsAsTestNames concatenate comments extra data,
   // which is output as system-output in XML.
-  oneAssertionPerTestcase: false
+  oneAssertionPerTestcase: false,
+
+  outputToFailure: false,
 };
 
 function converter(options) {
@@ -44,12 +46,21 @@ function converter(options) {
 
   tapParser.on('comment', function(comment) {
     if (options.oneAssertionPerTestcase) {
-      if (testCase.extra.length > 0) {
-        testCase.extra = [
-          testCase.extra[0] + comment
-        ]
+      if (options.outputToFailure) {
+        assert_idx = testCase.asserts.length-1;
+        if ("undefined" == typeof testCase.asserts[assert_idx].comment) {
+          testCase.asserts[assert_idx].comment = comment.substr(1).trim();
+        } else {
+          testCase.asserts[assert_idx].comment += '\n'+comment.substr(1).trim();
+        }
       } else {
-        testCase.extra.push(comment);
+        if (testCase.extra.length > 0) {
+          testCase.extra = [
+            testCase.extra[0] + comment
+          ]
+        } else {
+          testCase.extra.push(comment);
+        }
       }
     } else {
       // comment specifies boundaries between testsuites, unless feature disabled.
@@ -122,7 +133,7 @@ function converter(options) {
     });
 
     if (tapParser.sawValidTap && planPresent) {
-      var xmlString = serialize(testSuites);
+      var xmlString = serialize(testSuites, options);
       outStream.push(xmlString + '\n');
     } else {
       // Fail, no valid tap found (normally means no plan line present)

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -23,6 +23,10 @@ var defaults = {
 
   // Whether tap parser should be in strict mode or not, false by default.
   strict: false,
+
+  // Instead of CommentsAsTestNames concatenate comments extra data,
+  // which is output as system-output in XML.
+  oneAssertionPerTestcase: false
 };
 
 function converter(options) {
@@ -39,15 +43,25 @@ function converter(options) {
   var planPresent = false;
 
   tapParser.on('comment', function(comment) {
-    // comment specifies boundaries between testsuites, unless feature disabled.
-    if (options.dontUseCommentsAsTestNames) {
-      return;
+    if (options.oneAssertionPerTestcase) {
+      if (testCase.extra.length > 0) {
+        testCase.extra = [
+          testCase.extra[0] + comment
+        ]
+      } else {
+        testCase.extra.push(comment);
+      }
+    } else {
+      // comment specifies boundaries between testsuites, unless feature disabled.
+      if (options.dontUseCommentsAsTestNames) {
+        return;
+      }
+      if (noMoreTests) {
+        return;
+      }
+      // create new test
+      testCase = newTest(comment);
     }
-    if (noMoreTests) {
-      return;
-    }
-    // create new test
-    testCase = newTest(comment);
   });
 
   tapParser.on('plan', function() {
@@ -55,11 +69,14 @@ function converter(options) {
   });
 
   tapParser.on('assert', function(assert) {
-    // no test name was given, so all asserts go in a single test
-    if (!testCase) {
+    if (options.oneAssertionPerTestcase) {
       testCase = newTest('Default');
+    } else {
+      // no test name was given, so all asserts go in a single test
+      if (!testCase) {
+        testCase = newTest('Default');
+      }
     }
-
     testCase.asserts.push(assert);
   });
 

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -1,7 +1,7 @@
 var xmlbuilder = require('xmlbuilder');
 var sanitizeString = require('./sanitize-string');
 
-module.exports = function serialize (testCases) {
+module.exports = function serialize (testCases, options) {
   var rootXml = xmlbuilder.create('testsuites');
   testCases.forEach(function(suite) {
     var suiteElement = rootXml.ele('testsuite');
@@ -31,12 +31,18 @@ module.exports = function serialize (testCases) {
           failureElement = testCaseElement.ele('failure');
           if(a.diag) {
             failureElement.txt(formatFailure(a.diag));
+          } else if(a.comment) {
+            if(options.outputToFailure) {
+              failureElement.txt(sanitizeString(a.comment));
+            }
           }
       }
-      if(i === suite.asserts.length -1) {
-        suite.extra.forEach(function (extraContent) {
-          testCaseElement.ele('system-out', sanitizeString(extraContent));
-        });
+      if (!options.outputToFailure) {
+        if (i === suite.asserts.length -1) {
+          suite.extra.forEach(function (extraContent) {
+            testCaseElement.ele('system-out', sanitizeString(extraContent));
+          });
+        }
       }
     });
   });

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "xml2js": "^0.4.17"
   },
   "dependencies": {
+    "duplexer": "~0.1.1",
+    "minimist": "~1.2.0",
+    "tap-parser": "~1.2.2",
     "through2": "~2.0.0",
     "xmlbuilder": "~4.2.0",
-    "duplexer": "~0.1.1",
-    "tap-parser": "~1.2.2",
-    "xtend": "~4.0.0",
-    "minimist": "~1.2.0"
+    "xtend": "~4.0.0"
   }
 }


### PR DESCRIPTION
The default UseCommentsAsTestNames feature is non-standard.
For standard TAP output (http://testanything.org/) like produced by
Bats, comments indicate diagnostic output and without it essential
information about the test case is missing. It should be added to the
report grouped together with the assertion that produced it.

The change needed is fairly trivial. A CLI flag ``--oneAssertionPerTestCase`` is
created to enable the behaviour.